### PR TITLE
Fix: Add pre-commit instead of husky

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [ 18.15.x ]
+        node-version: [18.15.x]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Node js
@@ -29,22 +29,22 @@ jobs:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
-    - name: Check out repository code
-      uses: actions/checkout@v3
-    - name: Bumping version
-      id: bumping-version
-      uses: jpb06/bump-package@latest
-      with:
-        major-keywords: BREAKING CHANGE
-        minor-keywords: feat,Feat,minor
-        patch-keywords: fix,Fix
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - name: Bumping version
+        id: bumping-version
+        uses: jpb06/bump-package@latest
+        with:
+          major-keywords: BREAKING CHANGE
+          minor-keywords: feat,Feat,minor
+          patch-keywords: fix,Fix
     needs: test
 
   build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [ 18.15.x ]
+        node-version: [18.15.x]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Node js
@@ -53,7 +53,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies
         run: |
-          npm ci --omit=dev --ignore-scripts
+          npm ci
       - name: Build module
         run: |
           npm run build
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [ 18.15.x ]
+        node-version: [18.15.x]
     steps:
       - name: Download gitflows-stats artifact
         uses: actions/download-artifact@v3
@@ -83,7 +83,7 @@ jobs:
       - name: Set up Node js
         uses: actions/setup-node@v3
         with:
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: "https://registry.npmjs.org"
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,0 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
-npm run lint
-npm run prettier

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: "v2.7.1"
+    hooks:
+      - id: prettier
+  - repo: https://github.com/pre-commit/mirrors-eslint
+    rev: "v8.38.0"
+    hooks:
+      - id: eslint

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "test:coverage": "jest --coverage --collectCoverageFrom=\"./src/**\"",
     "lint": "eslint --fix . --ext .ts,.tsx,.jsx",
     "prettier": "prettier --write src",
-    "prepare": "husky install",
     "build": "tsc --build && cp -r templates dist && cp style.css dist"
   },
   "author": "Bertrand Bougon",
@@ -24,14 +23,12 @@
     "@typescript-eslint/eslint-plugin": "^5.56.0",
     "@typescript-eslint/parser": "^5.56.0",
     "eslint": "^8.36.0",
-    "husky": "^8.0.3",
     "jest": "^29.5.0",
     "jest-fetch-mock": "^3.0.3",
     "jest-html-reporters": "^3.1.4",
     "prettier": "^2.8.6",
     "ts-jest": "^29.0.5",
-    "ts-jest-resolver": "^2.0.1",
-    "typescript": "^5.0.2"
+    "ts-jest-resolver": "^2.0.1"
   },
   "dependencies": {
     "@types/parse-link-header": "^2.0.0",
@@ -44,7 +41,8 @@
     "moment": "^2.29.4",
     "open": "^9.0.0",
     "parse-link-header": "^2.0.0",
-    "pug": "^3.0.2"
+    "pug": "^3.0.2",
+    "typescript": "^5.0.2"
   },
   "jest": {
     "reporters": [


### PR DESCRIPTION
Husky was interfering in the publish job making the CI fails.
As we don't need pre-commit hooks to be run at this stage, better remove husky and use [pre-commit](https://pre-commit.com/) instead